### PR TITLE
Fix/dynamo db missing tablename

### DIFF
--- a/examples/dynamodb-local/appsync-config.json
+++ b/examples/dynamodb-local/appsync-config.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../../appsync-config.schema.json",
+  "schema": "./schema.graphql",
+  "apiConfig": {
+    "auth": [
+      {
+        "type": "API_KEY",
+        "key": "da2-test-api-key"
+      }
+    ]
+  },
+  "dataSources": [
+    {
+      "type": "DYNAMODB",
+      "name": "UsersTable",
+      "config": {
+        "tableName": "Users",
+        "region": "us-east-1",
+        "endpoint": "http://localhost:8001",
+        "accessKeyId": "fakeAccessKeyId",
+        "secretAccessKey": "fakeSecretAccessKey"
+      }
+    }
+  ],
+  "resolvers": [
+    {
+      "type": "Query",
+      "field": "getUser",
+      "kind": "Unit",
+      "dataSource": "UsersTable",
+      "file": "./resolvers/getUser.js"
+    },
+    {
+      "type": "Query",
+      "field": "listUsers",
+      "kind": "Unit",
+      "dataSource": "UsersTable",
+      "file": "./resolvers/listUsers.js"
+    },
+    {
+      "type": "Mutation",
+      "field": "createUser",
+      "kind": "Unit",
+      "dataSource": "UsersTable",
+      "file": "./resolvers/createUser.js"
+    },
+    {
+      "type": "Mutation",
+      "field": "deleteUser",
+      "kind": "Unit",
+      "dataSource": "UsersTable",
+      "file": "./resolvers/deleteUser.js"
+    }
+  ]
+}

--- a/examples/dynamodb-local/resolvers/createUser.js
+++ b/examples/dynamodb-local/resolvers/createUser.js
@@ -1,0 +1,30 @@
+// Create a new user using put() from @aws-appsync/utils/dynamodb
+import { util } from '@aws-appsync/utils';
+import { put } from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  const id = util.autoId();
+  const now = util.time.nowISO8601();
+
+  // Store the created item in stash for the response handler
+  ctx.stash.createdUser = {
+    id,
+    name: ctx.arguments.input.name,
+    email: ctx.arguments.input.email,
+    createdAt: now,
+  };
+
+  return put({
+    key: { id },
+    item: {
+      name: ctx.arguments.input.name,
+      email: ctx.arguments.input.email,
+      createdAt: now,
+    },
+  });
+}
+
+export function response(ctx) {
+  // PutItem doesn't return the item, so we return from stash
+  return ctx.stash.createdUser;
+}

--- a/examples/dynamodb-local/resolvers/deleteUser.js
+++ b/examples/dynamodb-local/resolvers/deleteUser.js
@@ -1,0 +1,12 @@
+// Delete a user using remove() from @aws-appsync/utils/dynamodb
+import { remove } from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  return remove({
+    key: { id: ctx.arguments.id },
+  });
+}
+
+export function response(ctx) {
+  return ctx.prev.result?.Attributes || { id: ctx.arguments.id };
+}

--- a/examples/dynamodb-local/resolvers/getUser.js
+++ b/examples/dynamodb-local/resolvers/getUser.js
@@ -1,0 +1,12 @@
+// Get a single user by ID using @aws-appsync/utils/dynamodb
+import { get } from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  return get({
+    key: { id: ctx.arguments.id },
+  });
+}
+
+export function response(ctx) {
+  return ctx.prev.result?.Item || null;
+}

--- a/examples/dynamodb-local/resolvers/listUsers.js
+++ b/examples/dynamodb-local/resolvers/listUsers.js
@@ -1,0 +1,11 @@
+// List all users using scan() from @aws-appsync/utils/dynamodb
+import { scan } from '@aws-appsync/utils/dynamodb';
+
+export function request(ctx) {
+  // This is the exact use case from the bug report - scan({}) with no params
+  return scan({});
+}
+
+export function response(ctx) {
+  return ctx.prev.result?.Items || [];
+}

--- a/examples/dynamodb-local/schema.graphql
+++ b/examples/dynamodb-local/schema.graphql
@@ -1,0 +1,21 @@
+type Query {
+  getUser(id: ID!): User
+  listUsers: [User!]!
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User!
+  deleteUser(id: ID!): User
+}
+
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  createdAt: String
+}
+
+input CreateUserInput {
+  name: String!
+  email: String!
+}

--- a/examples/dynamodb-local/setup-dynamodb.sh
+++ b/examples/dynamodb-local/setup-dynamodb.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Setup script for DynamoDB Local testing
+
+DYNAMODB_LOCAL_DIR=~/dynamodb-local
+ENDPOINT="http://localhost:8001"
+
+echo "=== Creating Users table in DynamoDB Local ==="
+
+# Create the Users table
+aws dynamodb create-table \
+  --endpoint-url $ENDPOINT \
+  --table-name Users \
+  --attribute-definitions AttributeName=id,AttributeType=S \
+  --key-schema AttributeName=id,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --no-cli-pager 2>/dev/null || echo "Table may already exist"
+
+echo ""
+echo "=== Seeding test data ==="
+
+# Seed some test users
+aws dynamodb put-item \
+  --endpoint-url $ENDPOINT \
+  --table-name Users \
+  --item '{
+    "id": {"S": "user-1"},
+    "name": {"S": "Alice Johnson"},
+    "email": {"S": "alice@example.com"},
+    "createdAt": {"S": "2024-01-01T00:00:00Z"}
+  }' \
+  --no-cli-pager
+
+aws dynamodb put-item \
+  --endpoint-url $ENDPOINT \
+  --table-name Users \
+  --item '{
+    "id": {"S": "user-2"},
+    "name": {"S": "Bob Smith"},
+    "email": {"S": "bob@example.com"},
+    "createdAt": {"S": "2024-01-02T00:00:00Z"}
+  }' \
+  --no-cli-pager
+
+aws dynamodb put-item \
+  --endpoint-url $ENDPOINT \
+  --table-name Users \
+  --item '{
+    "id": {"S": "user-3"},
+    "name": {"S": "Charlie Brown"},
+    "email": {"S": "charlie@example.com"},
+    "createdAt": {"S": "2024-01-03T00:00:00Z"}
+  }' \
+  --no-cli-pager
+
+echo ""
+echo "=== Verifying data (scan table) ==="
+aws dynamodb scan \
+  --endpoint-url $ENDPOINT \
+  --table-name Users \
+  --no-cli-pager
+
+echo ""
+echo "=== Setup complete! ==="
+echo "DynamoDB Local is ready with 3 test users."

--- a/src/datasourceHandlers/index.ts
+++ b/src/datasourceHandlers/index.ts
@@ -1,7 +1,7 @@
 import type {
   DataSource,
   DynamoDataSource,
-  DynamoRequest,
+  DynamoOperation,
   HTTPDataSource,
   HTTPRequest,
   LambdaDataSource,
@@ -13,6 +13,156 @@ import { executeDynamoOperation, getDynamoClient } from './dynamo.js';
 import { executeHTTPOperation } from './http.js';
 import { executeLambdaOperation } from './lambda.js';
 import { executeRDSOperation } from './rds.js';
+
+// Types for AppSync expression objects
+interface ExpressionInput {
+  expression: string;
+  expressionNames?: Record<string, string>;
+  expressionValues?: Record<string, unknown>;
+}
+
+/** Apply condition expression to params, merging with existing expression attributes */
+function applyCondition(params: Record<string, unknown>, condition: ExpressionInput): void {
+  params.ConditionExpression = condition.expression;
+  if (condition.expressionNames) {
+    params.ExpressionAttributeNames = { ...(params.ExpressionAttributeNames as object), ...condition.expressionNames };
+  }
+  if (condition.expressionValues) {
+    params.ExpressionAttributeValues = {
+      ...(params.ExpressionAttributeValues as object),
+      ...condition.expressionValues,
+    };
+  }
+}
+
+/** Apply filter expression to params, merging with existing expression attributes */
+function applyFilter(params: Record<string, unknown>, filter: ExpressionInput): void {
+  params.FilterExpression = filter.expression;
+  if (filter.expressionNames) {
+    params.ExpressionAttributeNames = { ...(params.ExpressionAttributeNames as object), ...filter.expressionNames };
+  }
+  if (filter.expressionValues) {
+    params.ExpressionAttributeValues = { ...(params.ExpressionAttributeValues as object), ...filter.expressionValues };
+  }
+}
+
+/** Parse nextToken from base64 to ExclusiveStartKey */
+function parseNextToken(nextToken: string): unknown {
+  return JSON.parse(Buffer.from(nextToken, 'base64').toString());
+}
+
+/** Apply common scan/query options to params */
+function applyScanQueryOptions(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.index) params.IndexName = request.index;
+  if (request.limit) params.Limit = request.limit;
+  if (request.nextToken) params.ExclusiveStartKey = parseNextToken(request.nextToken as string);
+  if (request.consistentRead !== undefined) params.ConsistentRead = request.consistentRead;
+  if (request.select) params.Select = request.select;
+  if (request.filter) applyFilter(params, request.filter as ExpressionInput);
+}
+
+/** Transform GetItem request */
+function transformGetItem(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.key) params.Key = request.key;
+  if (request.consistentRead !== undefined) params.ConsistentRead = request.consistentRead;
+  if (request.projection) {
+    const proj = request.projection as string[];
+    params.ProjectionExpression = proj.map((_, i) => `#p${i}`).join(', ');
+    params.ExpressionAttributeNames = Object.fromEntries(proj.map((p, i) => [`#p${i}`, p]));
+  }
+}
+
+/** Transform PutItem request */
+function transformPutItem(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  params.Item = { ...(request.key as object), ...(request.attributeValues as object) };
+  if (request.condition) applyCondition(params, request.condition as ExpressionInput);
+}
+
+/** Transform UpdateItem request */
+function transformUpdateItem(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.key) params.Key = request.key;
+  if (request.update) {
+    const upd = request.update as ExpressionInput;
+    params.UpdateExpression = upd.expression;
+    if (upd.expressionNames) params.ExpressionAttributeNames = upd.expressionNames;
+    if (upd.expressionValues) params.ExpressionAttributeValues = upd.expressionValues;
+  }
+  if (request.condition) applyCondition(params, request.condition as ExpressionInput);
+  params.ReturnValues = 'ALL_NEW';
+}
+
+/** Transform DeleteItem request */
+function transformDeleteItem(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.key) params.Key = request.key;
+  if (request.condition) applyCondition(params, request.condition as ExpressionInput);
+}
+
+/** Transform Query request */
+function transformQuery(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.query) {
+    const q = request.query as ExpressionInput;
+    params.KeyConditionExpression = q.expression;
+    if (q.expressionNames) params.ExpressionAttributeNames = q.expressionNames;
+    if (q.expressionValues) params.ExpressionAttributeValues = q.expressionValues;
+  }
+  applyScanQueryOptions(params, request);
+  if (request.scanIndexForward !== undefined) params.ScanIndexForward = request.scanIndexForward;
+}
+
+/** Transform Scan request */
+function transformScan(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  applyScanQueryOptions(params, request);
+  if (request.totalSegments !== undefined) params.TotalSegments = request.totalSegments;
+  if (request.segment !== undefined) params.Segment = request.segment;
+}
+
+/** Transform batch/transact operations */
+function transformBatchTransact(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  delete params.TableName; // Not used at top level for batch/transact
+  if (request.tables) params.RequestItems = request.tables;
+  if (request.transactItems) params.TransactItems = request.transactItems;
+}
+
+/** Transform Sync request */
+function transformSync(params: Record<string, unknown>, request: Record<string, unknown>): void {
+  if (request.filter) applyFilter(params, request.filter as ExpressionInput);
+  if (request.limit) params.Limit = request.limit;
+  if (request.nextToken) params.ExclusiveStartKey = parseNextToken(request.nextToken as string);
+}
+
+/**
+ * Transform AppSync-style DynamoDB request to AWS SDK format
+ * AppSync uses camelCase, SDK uses PascalCase
+ */
+function transformDynamoRequest(
+  request: Record<string, unknown>,
+  tableName: string
+): { operation: DynamoOperation; params: Record<string, unknown> } {
+  const operation = request.operation as DynamoOperation;
+  const params: Record<string, unknown> = { TableName: tableName };
+
+  const transformers: Record<string, (p: Record<string, unknown>, r: Record<string, unknown>) => void> = {
+    GetItem: transformGetItem,
+    PutItem: transformPutItem,
+    UpdateItem: transformUpdateItem,
+    DeleteItem: transformDeleteItem,
+    Query: transformQuery,
+    Scan: transformScan,
+    BatchGetItem: transformBatchTransact,
+    BatchPutItem: transformBatchTransact,
+    BatchDeleteItem: transformBatchTransact,
+    TransactGetItems: transformBatchTransact,
+    TransactWriteItems: transformBatchTransact,
+    Sync: transformSync,
+  };
+
+  const transformer = transformers[operation];
+  if (transformer) {
+    transformer(params, request);
+  }
+
+  return { operation, params };
+}
 
 /** Handle data source execution */
 export async function executeDataSource(
@@ -28,8 +178,12 @@ export async function executeDataSource(
 
   switch (dataSource.type) {
     case 'DYNAMODB': {
-      const { operation, params } = request as DynamoRequest;
-      const docClient = getDynamoClient(dataSource as DynamoDataSource);
+      const dynamoDS = dataSource as DynamoDataSource;
+      const { operation, params } = transformDynamoRequest(
+        request as Record<string, unknown>,
+        dynamoDS.config.tableName
+      );
+      const docClient = getDynamoClient(dynamoDS);
       return executeDynamoOperation(docClient, operation, params);
     }
 

--- a/tests/unit/datasourceHandlers/dynamoTransform.test.ts
+++ b/tests/unit/datasourceHandlers/dynamoTransform.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Mock the dynamo module to capture what params are sent
+jest.unstable_mockModule('../../../src/datasourceHandlers/dynamo.js', () => ({
+  getDynamoClient: jest.fn().mockReturnValue({ send: jest.fn() }),
+  executeDynamoOperation: jest.fn().mockImplementation(async (_client, _op, params) => {
+    // Return the params so we can inspect them
+    return { _testParams: params };
+  }),
+}));
+
+describe('DynamoDB Request Transformation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('executeDataSource with DYNAMODB', () => {
+    it('should inject TableName from data source config for scan({})', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      // This is what scan({}) returns from @aws-appsync/utils/dynamodb
+      const request = { operation: 'Scan' };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+
+      // Verify TableName was injected
+      expect((result as { _testParams: Record<string, unknown> })._testParams).toMatchObject({
+        TableName: 'users-table',
+      });
+    });
+
+    it('should transform scan with limit and filter', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      // This is what scan({ limit: 10, filter: {...} }) returns
+      const request = {
+        operation: 'Scan',
+        limit: 10,
+        filter: {
+          expression: '#status = :status',
+          expressionNames: { '#status': 'status' },
+          expressionValues: { ':status': 'active' },
+        },
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        Limit: 10,
+        FilterExpression: '#status = :status',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':status': 'active' },
+      });
+    });
+
+    it('should transform GetItem request with key', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      // This is what get({ key: { id: '123' } }) returns
+      const request = {
+        operation: 'GetItem',
+        key: { id: '123' },
+        consistentRead: true,
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        Key: { id: '123' },
+        ConsistentRead: true,
+      });
+    });
+
+    it('should transform PutItem request', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      // This is what put({ key: { id }, item: { name, email } }) returns
+      const request = {
+        operation: 'PutItem',
+        key: { id: '123' },
+        attributeValues: { name: 'John', email: 'john@example.com' },
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        Item: { id: '123', name: 'John', email: 'john@example.com' },
+      });
+    });
+
+    it('should transform UpdateItem request', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      const request = {
+        operation: 'UpdateItem',
+        key: { id: '123' },
+        update: {
+          expression: 'SET #name = :name',
+          expressionNames: { '#name': 'name' },
+          expressionValues: { ':name': 'Jane' },
+        },
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        Key: { id: '123' },
+        UpdateExpression: 'SET #name = :name',
+        ExpressionAttributeNames: { '#name': 'name' },
+        ExpressionAttributeValues: { ':name': 'Jane' },
+        ReturnValues: 'ALL_NEW',
+      });
+    });
+
+    it('should transform DeleteItem request', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      const request = {
+        operation: 'DeleteItem',
+        key: { id: '123' },
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        Key: { id: '123' },
+      });
+    });
+
+    it('should transform Query request', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      const request = {
+        operation: 'Query',
+        query: {
+          expression: '#pk = :pk',
+          expressionNames: { '#pk': 'pk' },
+          expressionValues: { ':pk': 'USER#123' },
+        },
+        index: 'GSI1',
+        limit: 20,
+        scanIndexForward: false,
+      };
+
+      const result = await executeDataSource('UsersTable', dataSources, request);
+      const params = (result as { _testParams: Record<string, unknown> })._testParams;
+
+      expect(params).toMatchObject({
+        TableName: 'users-table',
+        KeyConditionExpression: '#pk = :pk',
+        ExpressionAttributeNames: { '#pk': 'pk' },
+        ExpressionAttributeValues: { ':pk': 'USER#123' },
+        IndexName: 'GSI1',
+        Limit: 20,
+        ScanIndexForward: false,
+      });
+    });
+
+    it('should throw error for unknown data source', async () => {
+      const { executeDataSource } = await import('../../../src/datasourceHandlers/index.js');
+
+      const dataSources = [
+        {
+          name: 'UsersTable',
+          type: 'DYNAMODB' as const,
+          config: {
+            tableName: 'users-table',
+            region: 'us-east-1',
+          },
+        },
+      ];
+
+      await expect(executeDataSource('UnknownTable', dataSources, { operation: 'Scan' })).rejects.toThrow(
+        "Data source 'UnknownTable' not found"
+      );
+    });
+  });
+});


### PR DESCRIPTION
When using @aws-appsync/utils/dynamodb helpers like scan({}), get(), put(), etc., the TableName was not being injected from the data source configuration, causing all DynamoDB operations to fail.

### Root Cause
The executeDataSource function in src/datasourceHandlers/index.ts incorrectly destructured the resolver request:

#### Before (bug)
```js
const { operation, params } = request;  // params was undefined!
executeDynamoOperation(docClient, operation, params);
```

When a resolver returns scan({}), it produces { operation: 'Scan' } with no params property. The code expected a different shape and never injected the table name.

#### The Fix
Added transformDynamoRequest() function that:
1. Injects TableName from dataSource.config.tableName
2. Transforms AppSync-style fields (camelCase) to AWS SDK format (PascalCase):

- key → Key
- limit → Limit
- filter.expression → FilterExpression
- query.expression → KeyConditionExpression